### PR TITLE
Persist process pool

### DIFF
--- a/migration/constants.py
+++ b/migration/constants.py
@@ -9,7 +9,7 @@ MIN_POPULATION = 1900000
 POPULATION_SCALE = 1 / 1000
 
 # Agents with a Migration score above this threshold will migrate.
-MIGRATION_THRESHOLD = 0.8
+MIGRATION_THRESHOLD = 0.7825
 
 # Any income above this level multiplied by the country's GDP is brought
 # down to this level.
@@ -21,4 +21,4 @@ THREADS = cpu_count() - 1
 # We need to pass pieces of the array to each process so it can do some work;
 # however, pieces that are too large cannot be passed. SPLITS determines how
 # arrays as subspliced to reduce their size.
-SPLITS = int(1000 * POPULATION_SCALE) if POPULATION_SCALE > 1 / 1000 else 1
+SPLITS = int(100 * POPULATION_SCALE) if POPULATION_SCALE > 1 / 100 else 1


### PR DESCRIPTION
This saves some overhead by not needing to close and reopen threads each time an operation is run.

The following graph shows speed improvements on a machine with 48 cores.

![70mprocess-scale-speed](https://user-images.githubusercontent.com/9517688/27610495-86d47db8-5b5c-11e7-9a7c-c4bfe6d8a77d.png)

Output now looks like the following:

```
Migration model completed at a scale of 1000:1.
There were a total of 37156 migrants.
Ethiopia      -10060
Myanmar        -9717
Afghanistan    -7760
Uganda         -2536
Iraq           -2121
dtype: int64
New Zealand    348
Canada         349
Switzerland    355
Denmark        356
Qatar          439
dtype: int64
The migrants came from
Ethiopia                            10165
Myanmar                              9824
Afghanistan                          7863
Uganda                               2697
Iraq                                 2292
Thailand                             1519
Zambia                                985
Nicaragua                             672
Malawi                                423
Mali                                  382
India                                 185
Democratic Republic of the Congo       80
Central African Republic               33
Bulgaria                               28
Yemen                                   8
Name: Country, dtype: int64
```