### PR TITLE
Allow arbitrary returns from run.

### DIFF
--- a/gos.py
+++ b/gos.py
@@ -19,7 +19,7 @@ class Globe:
         self_dict = self.__dict__.copy()
         del self_dict['pool']
         return self_dict
-    
+
     def max_value(self, attribute):
         """
         Returns the maximum value for an attribute.
@@ -35,11 +35,11 @@ class Globe:
         country_array.index = range(len(country_array))
         # Garbage collect before creating new processes.
         gc.collect()
-        self.agents = pd.concat(self.pool.imap_unordered(self._gen_agents, np.array_split(country_array, self.threads * self.splits)))
+        self.agents = pd.concat(self.pool.imap(self._gen_agents, np.array_split(country_array, self.threads * self.splits)))#.sort_index()
 
     def run(self, function, **kwargs):
         # Garbage collect before creating new processes.
         gc.collect()
-        self.agents = pd.concat(self.pool.imap_unordered(partial(function, **kwargs),
-                                                         np.array_split(self.agents,
-                                                                        self.threads * self.splits)))
+        return pd.concat(self.pool.imap(partial(function, **kwargs),
+                                        np.array_split(self.agents,
+                                                       self.threads * self.splits)))

--- a/migration/migration.py
+++ b/migration/migration.py
@@ -39,7 +39,7 @@ def generate_agents(df, country, population):
 
 def migrate_array(a, **kwargs):
     if len(a[a.Migration > MIGRATION_THRESHOLD]) == 0:
-        return a
+        return a.Location
     migration_map = kwargs["migration_map"]
     countries = kwargs["countries"]
     for country, population in a.groupby("Location"):
@@ -47,7 +47,7 @@ def migrate_array(a, **kwargs):
         local_attraction /= local_attraction.sum()
         migrants_num = len(population[population.Migration > MIGRATION_THRESHOLD])
         a.loc[(a.Country == country) & (a.Migration > MIGRATION_THRESHOLD), "Location"] = np.random.choice(countries, p=local_attraction, size=migrants_num, replace=True)
-    return a
+    return a.Location
 
 def migrate_score(income, attachment, employed, conflict):
     return np.array(((10 * (1 + income / -np.max(income)) +
@@ -78,7 +78,7 @@ def main():
         local_attraction[local_attraction.index.isin(neighbors(country))] += 1
         migration_map[country] = local_attraction
 
-    globe.run(migrate_array, migration_map=migration_map, countries=globe.df.index)
+    globe.agents["Location"] = globe.run(migrate_array, migration_map=migration_map, countries=globe.df.index)
 
     print("Migration model completed at a scale of {}:1.".format(int(1 / POPULATION_SCALE)))
     migrants = globe.agents[globe.agents.Country != globe.agents.Location]

--- a/migration/migration.py
+++ b/migration/migration.py
@@ -49,7 +49,7 @@ def migrate_array(a, **kwargs):
         a.loc[(a.Country == country) & (a.Migration > MIGRATION_THRESHOLD), "Location"] = np.random.choice(countries, p=local_attraction, size=migrants_num, replace=True)
     return a.Location
 
-def ms(a, **kwargs):
+def migrate_score(a, **kwargs):
     max_income = kwargs["max_income"]
     conflict_scores = kwargs["conflict"]
     max_conflict = kwargs["max_conflict"]
@@ -60,20 +60,13 @@ def ms(a, **kwargs):
              3 + a.Employed * 4)
             / 32).astype('float32')
 
-def migrate_score(income, attachment, employed, conflict):
-    return np.array(((10 * (1 + income / -np.max(income)) +
-                      10 * attachment +
-                      (5 * conflict / np.max(conflict)) +
-                      3 + employed * 4)
-                     / 32), dtype='float32')
-
 def main():
     np.random.seed(0)
     globe = gos.Globe(data.all(), threads=THREADS, splits=SPLITS)
 
     globe.create_agents(generate_agents)
 
-    globe.agents.Migration = globe.run(ms, max_income=globe.agents.Income.max(),
+    globe.agents.Migration = globe.run(migrate_score, max_income=globe.agents.Income.max(),
                                        conflict=globe.df[["Conflict"]],
                                        max_conflict=globe.df.Conflict.max())
 


### PR DESCRIPTION
Optimizes the migration score calculation.

The model now passes back the minimal possible information from each process. This saves significant computation time in concatenating process results.

| Version | Average Time (s) |
|:-|:-
| Old | 11.91 |
| New | 8.25 |

