### PR TITLE
Minimize the number of columns sent to the process pool.

### DIFF
--- a/gos.py
+++ b/gos.py
@@ -38,8 +38,9 @@ class Globe:
         self.agents = pd.concat(self.pool.imap(self._gen_agents, np.array_split(country_array, self.threads * self.splits)))#.sort_index()
 
     def run(self, function, **kwargs):
+        columns = kwargs["columns"] if "columns" in kwargs else self.agents.columns
         # Garbage collect before creating new processes.
         gc.collect()
         return pd.concat(self.pool.imap(partial(function, **kwargs),
-                                        np.array_split(self.agents,
+                                        np.array_split(self.agents[columns],
                                                        self.threads * self.splits)))

--- a/migration/migration.py
+++ b/migration/migration.py
@@ -53,7 +53,7 @@ def migrate_score(a, **kwargs):
     max_income = kwargs["max_income"]
     conflict_scores = kwargs["conflict"]
     max_conflict = kwargs["max_conflict"]
-    conflict = conflict_scores.merge(a, left_index=True, right_on='Country')["Conflict"] / max_conflict
+    conflict = conflict_scores.merge(a, left_index=True, right_on='Location')["Conflict"] / max_conflict
     return ((10 * (1 + a.Income / -max_income) +
              10 * a.Attachment +
              (5 * conflict) +
@@ -68,7 +68,8 @@ def main():
 
     globe.agents.Migration = globe.run(migrate_score, max_income=globe.agents.Income.max(),
                                        conflict=globe.df[["Conflict"]],
-                                       max_conflict=globe.df.Conflict.max())
+                                       max_conflict=globe.df.Conflict.max(),
+                                       columns=["Income", "Employed", "Attachment", "Location"])
 
     attractiveness = ((1 - globe.df["Conflict"] / globe.max_value("Conflict")) +
                       (globe.df["GDP"] / globe.max_value("GDP")) +
@@ -84,7 +85,9 @@ def main():
         local_attraction[local_attraction.index.isin(neighbors(country))] += 1
         migration_map[country] = local_attraction
 
-    globe.agents["Location"] = globe.run(migrate_array, migration_map=migration_map, countries=globe.df.index)
+    globe.agents["Location"] = globe.run(migrate_array, migration_map=migration_map,
+                                         countries=globe.df.index,
+                                         columns=["Country", "Location", "Migration"])
 
     print("Migration model completed at a scale of {}:1.".format(int(1 / POPULATION_SCALE)))
     migrants = globe.agents[globe.agents.Country != globe.agents.Location]


### PR DESCRIPTION
This is a similar optimization to the one used in #10.

Instead of having slices of the entire DataFrame sent to the process pool, allow only the necessary columns to be selected. This minimizes both the processes time required to split the DataFrame--which is a single-process task--and the memory required to run the program.

| Version | Average Time (s) |
|:-|:-
| Old | 8.25
| New | 7.54